### PR TITLE
Refactor tests

### DIFF
--- a/test/deepcopy_test.lua
+++ b/test/deepcopy_test.lua
@@ -1,0 +1,101 @@
+require('luacov')
+local testcase = require('testcase')
+local assert = require('assert')
+local deepcopy = require('metamodule.deepcopy')
+
+function testcase.returns_non_table_values_unchanged()
+    -- non-table values are returned as-is without copying
+    for _, v in ipairs({
+        nil,
+        true,
+        false,
+        0,
+        3.14,
+        'hello',
+        function()
+        end,
+    }) do
+        local result, err = deepcopy(v, 'key', {})
+        assert.equal(result, v)
+        assert.is_nil(err)
+    end
+end
+
+function testcase.copies_flat_table()
+    local src = {
+        a = 1,
+        b = 'hello',
+        c = true,
+    }
+    local result, err = deepcopy(src, 'root', {})
+    assert.is_nil(err)
+    -- content is preserved
+    assert.equal(result, src)
+    -- the copy is a distinct table object
+    assert.is_true(result ~= src)
+end
+
+function testcase.copies_nested_table()
+    local src = {
+        level1 = {
+            level2 = {
+                value = 42,
+            },
+        },
+    }
+    local result, err = deepcopy(src, 'root', {})
+    assert.is_nil(err)
+    assert.equal(result.level1.level2.value, 42)
+    -- each nested table is a distinct copy
+    assert.is_true(result.level1 ~= src.level1)
+    assert.is_true(result.level1.level2 ~= src.level1.level2)
+end
+
+function testcase.copy_does_not_share_references()
+    local src = {
+        nested = {
+            x = 1,
+        },
+    }
+    local result, err = deepcopy(src, 'root', {})
+    assert.is_nil(err)
+    -- mutating the copy must not affect the original
+    result.nested.x = 99
+    assert.equal(src.nested.x, 1)
+end
+
+function testcase.error_on_direct_circular_reference()
+    -- a table that directly references itself
+    local t = {}
+    t.self = t
+    local result, err = deepcopy(t, 'root', {})
+    assert.is_nil(result)
+    assert.is_string(err)
+    assert.match(err, 'circularly referenced')
+end
+
+function testcase.error_on_indirect_circular_reference()
+    -- a → b → a: deepcopy must detect the cycle and return an error
+    local a = {}
+    local b = {
+        ref = a,
+    }
+    a.ref = b
+    local result, err = deepcopy(a, 'root', {})
+    assert.is_nil(result)
+    assert.is_string(err)
+    assert.match(err, 'circularly referenced')
+end
+
+function testcase.error_propagates_from_nested_copy()
+    -- a nested value that causes a circular error must bubble up
+    local inner = {}
+    inner.loop = inner
+    local outer = {
+        child = inner,
+    }
+    local result, err = deepcopy(outer, 'root', {})
+    assert.is_nil(result)
+    assert.is_string(err)
+    assert.match(err, 'circularly referenced')
+end

--- a/test/eval_test.lua
+++ b/test/eval_test.lua
@@ -1,23 +1,29 @@
 require('luacov')
 local testcase = require('testcase')
+local assert = require('assert')
 local eval = require('metamodule.eval')
 
-function testcase.eval()
-    local src = 'return hello'
-    local env = {
+function testcase.eval_with_env()
+    -- test that eval compiles src and applies the given environment
+    local fn, err = eval('return hello', {
         hello = 'world',
-    }
-
-    -- test that create a function from source string
-    local fn, err = eval(src, env)
+    })
     assert.is_nil(err)
     assert.is_function(fn)
-
-    -- test that return a value from function
     assert.equal(fn(), 'world')
+end
 
-    -- test that return an error if source string is invalid
-    fn, err = eval('retur hello')
+function testcase.eval_without_env()
+    -- test that eval works when no environment is provided (uses default globals)
+    local fn, err = eval('return type("hello")')
+    assert.is_nil(err)
+    assert.is_function(fn)
+    assert.equal(fn(), 'string')
+end
+
+function testcase.eval_syntax_error()
+    -- test that a syntax error returns nil + error string
+    local fn, err = eval('retur hello')
     assert.is_nil(fn)
     assert.is_string(err)
 end

--- a/test/is_test.lua
+++ b/test/is_test.lua
@@ -1,8 +1,9 @@
 require('luacov')
 local testcase = require('testcase')
+local assert = require('assert')
 local is = require('metamodule.is')
 
-function testcase.isPackageName()
+function testcase.package_name()
     -- test that return true
     for _, v in ipairs({
         'foo',
@@ -30,7 +31,7 @@ function testcase.isPackageName()
     end
 end
 
-function testcase.isModuleName()
+function testcase.module_name()
     -- test that return true
     for _, v in ipairs({
         'Foo',
@@ -55,7 +56,7 @@ function testcase.isModuleName()
     end
 end
 
-function testcase.isMetamethodName()
+function testcase.metamethod_name()
     -- test that return true
     for _, v in ipairs({
         '__tostring',

--- a/test/metamodule_test.lua
+++ b/test/metamodule_test.lua
@@ -1,128 +1,614 @@
 require('luacov')
 local testcase = require('testcase')
+local assert = require('assert')
+local mm = require('metamodule')
+
+local function run(cmd)
+    local f = assert(io.popen(cmd))
+    f:read('*a')
+    f:close()
+end
 
 function testcase.before_all()
-    -- install hello and world module
-    local f = assert(io.popen(table.concat({
-        'cd testdata',
-        'luarocks make metamodule-test-hello-scm-1.rockspec',
-        'luarocks make metamodule-test-world-scm-1.rockspec',
-    }, ' && ')))
-    for line in f:lines() do
-        print(line)
-    end
-    f:close()
+    -- install the hello and world test modules as real luarocks packages.
+    -- these modules are located under a path containing 'metamodule', so
+    -- get_pkgname() uses the require-argument (getlocal) fallback to detect
+    -- their package names rather than the file-path based pathname2modname.
+    run('cd testdata && luarocks make metamodule-test-hello-scm-1.rockspec 2>&1')
+    run('cd testdata && luarocks make metamodule-test-world-scm-1.rockspec 2>&1')
 end
 
 function testcase.after_all()
-    -- install hello and world module
-    local f = assert(io.popen(table.concat({
-        'cd testdata',
-        'luarocks remove metamodule-test-hello',
-        'luarocks remove metamodule-test-world',
-    }, ' && ')))
-    for line in f:lines() do
-        print(line)
-    end
-    f:close()
+    run('luarocks remove metamodule-test-hello 2>&1')
+    run('luarocks remove metamodule-test-world 2>&1')
 end
 
-function testcase.hello()
-    -- test that check module is declared with metamodule
-    local hello
-    assert(pcall(function()
-        hello = require('metamodule.test.hello')
-    end))
+-- =============================================================================
+-- Integration tests: modules loaded via require with correct package names
+-- =============================================================================
+
+function testcase.hello_module()
+    -- module declared as metamodule.new(Hello) (non-TCO __call form).
+    -- package name detected from require argument via getlocal.
+    local hello = require('metamodule.test.hello')
     local h = hello.new()
+
     assert.equal(h._NAME, 'metamodule.test.hello')
     assert.equal(h._PACKAGE, 'metamodule.test.hello')
     assert.match(h, '^metamodule%.test%.hello: ', false)
     assert.equal(h.val, 'hello-value')
 
-    -- test that return a module name
+    -- instanceof() with no args returns the registered name
     assert.equal(h:instanceof(), 'metamodule.test.hello')
 
-    -- test that call method
+    -- regular method
     assert.equal(h:say(), 'metamodule.test.hello hello-value')
 
-    -- test that call __index metamethod
+    -- custom __index: unknown keys are handled by the metamethod
     assert.equal(h:foo(), tostring(h) .. ': __index foo')
 end
 
-function testcase.world_based_on_hello()
-    -- test that check module is declared with metamodule
-    local hello
-    local world
-    assert(pcall(function()
-        world = require('metamodule.test.world')
-        hello = require('metamodule.test.hello')
-    end))
+function testcase.world_module()
+    -- world is declared with new.World(...) (__index named form) and embeds hello.
+    -- package name detected via require argument since source path has 'metamodule'.
+    local hello = require('metamodule.test.hello')
+    local world = require('metamodule.test.world')
+    local h = hello.new()
     local w = world.new()
+
+    -- _NAME includes the 'World' suffix added by the named-module form
     assert.equal(w._NAME, 'metamodule.test.world.World')
     assert.equal(w._PACKAGE, 'metamodule.test.world')
     assert.match(w, '^metamodule%.test%.world%.World: ', false)
     assert.equal(w.val, 'world-value')
-    local h = hello.new()
+
+    -- say() is inherited from hello (same function reference)
     assert.equal(w.say, h.say)
 
-    -- test that contains a base module methods
+    -- embedded module methods are also accessible by registered name
     assert.equal(w['metamodule.test.hello'], {
         init = h.init,
         say = h.say,
         instanceof = h.instanceof,
     })
 
-    -- test that return a module name
     assert.equal(w:instanceof(), 'metamodule.test.world.World')
-
-    -- test that call method
     assert.equal(w:say(), 'metamodule.test.world.World world-value')
-
-    -- test that call method
     assert.equal(w:say2(), 'metamodule.test.world.World say2 world-value')
 
-    -- test that call __index metamethod
+    -- __index metamethod inherited from hello
     assert.equal(w:bar(), tostring(w) .. ': __index bar')
 end
 
-function testcase.instanceof()
-    local hello
-    local world
-    assert(pcall(function()
-        world = require('metamodule.test.world')
-        hello = require('metamodule.test.hello')
-    end))
-    local w = world.new()
-    local h = hello.new()
-    local metamodule = require('metamodule')
+function testcase.pkgname_tco_call_form()
+    -- when `return metamodule.new(decl)` is the last statement in a module
+    -- file, the module's Lua frame is eliminated by tail-call optimisation.
+    -- get_pkgname() must recover the package name from require's argument
+    -- via debug.getlocal instead of the (missing) source-file path.
+    local modname = 'test.mm.tco'
+    package.preload[modname] = function()
+        local M = {
+            val = 'tco',
+        }
+        function M:greet()
+            return self._NAME .. ' ' .. self.val
+        end
+        return mm.new(M) -- tail call: module frame eliminated by TCO
+    end
+    local new_m = require(modname)
+    local obj = new_m()
 
-    -- test that return true
-    assert.is_true(metamodule.instanceof(h, 'metamodule.test.hello'))
-    assert.is_true(metamodule.instanceof(w, 'metamodule.test.world.World'))
-    assert.is_true(metamodule.instanceof(w, 'metamodule.test.hello'))
+    assert.equal(obj._NAME, modname)
+    assert.equal(obj._PACKAGE, modname)
+    assert.equal(obj:greet(), modname .. ' tco')
 
-    -- test that return false
-    assert.is_false(metamodule.instanceof(h, 'foo'))
+    assert.is_true(mm.instanceof(obj, modname))
+end
 
-    -- test that return false if obj is invalid
-    assert.is_false(metamodule.instanceof('foo', 'bar'))
-    assert.is_false(metamodule.instanceof({
+function testcase.pkgname_named_module_in_require()
+    -- when mm.new.ModName(decl) is used inside a require'd module, the source
+    -- path is filtered (contains 'metamodule') so get_pkgname falls back to
+    -- getlocal, correctly resolving pkgname to the require argument.
+    local modname = 'test.mm.namedmod'
+    package.preload[modname] = function()
+        local M = {}
+        return {
+            new = mm.new.NamedMod(M),
+        }
+    end
+    local mod = require(modname)
+    local obj = mod.new()
+
+    assert.equal(obj._NAME, modname .. '.NamedMod')
+    assert.equal(obj._PACKAGE, modname)
+end
+
+-- =============================================================================
+-- metamodule.new validation errors
+-- =============================================================================
+
+function testcase.new_error_invalid_module_name()
+    -- module names must be PascalCase: ^[A-Z][a-zA-Z0-9]*$
+    local err = assert.throws(function()
+        mm.new.fooBar({}) -- starts with lowercase
+    end)
+    assert.match(err, 'module name must be the following pattern string')
+end
+
+function testcase.new_error_no_module_name()
+    -- calling the __call form outside require: pkgname=nil, modname=nil → error
+    local err = assert.throws(function()
+        mm.new({})
+    end)
+    assert.match(err, 'module name must not be nil')
+end
+
+function testcase.new_error_non_table_decl()
+    local err = assert.throws(function()
+        mm.new.NewNonTableDecl('not-a-table')
+    end)
+    assert.match(err, 'module declaration must be table')
+end
+
+function testcase.new_error_already_registered_no_pkgname()
+    -- second registration of the same name without a package must fail
+    mm.new.AlreadyReg({})
+    local err = assert.throws(function()
+        mm.new.AlreadyReg({})
+    end)
+    assert.match(err, 'already defined')
+end
+
+function testcase.new_error_already_registered_with_pkgname()
+    -- when the module is loaded from require and is already registered,
+    -- the error message includes the package name
+    local modname = 'test.mm.dupreg'
+    package.preload[modname] = function()
+        local M = {}
+        return {
+            new = mm.new.DupPkg(M),
+        }
+    end
+    require(modname)
+    package.loaded[modname] = nil -- clear cache to force re-execution
+    local err = assert.throws(function()
+        require(modname)
+    end)
+    assert.match(err, 'already defined in package')
+end
+
+function testcase.new_table_is_readonly()
+    -- metamodule.new is a protected proxy table; assignment must error
+    local err = assert.throws(function()
+        mm.new.foo = 'bar'
+    end)
+    assert.match(err, 'attempt to assign to a readonly property')
+end
+
+-- =============================================================================
+-- inspect() validation errors
+-- =============================================================================
+
+function testcase.inspect_error_non_string_key()
+    local err = assert.throws(function()
+        mm.new.InspNonStr({
+            [1] = 'value',
+        })
+    end)
+    assert.match(err, 'field name must be string')
+end
+
+function testcase.inspect_error_reserved_fields()
+    -- constructor, instanceof, and identity fields (_NAME/_PACKAGE/_STRING) are reserved
+    for i, field in ipairs({
+        'constructor',
+        'instanceof',
+        '_NAME',
+        '_PACKAGE',
+        '_STRING',
+    }) do
+        local decl = {}
+        decl[field] = 'value'
+        local err = assert.throws(function()
+            mm.new['InspReserved' .. i](decl)
+        end)
+        assert.match(err, 'reserved field')
+    end
+end
+
+function testcase.inspect_error_metamethod_must_be_function()
+    -- metamethods listed with type 'function' in METAFIELD_TYPES must be functions
+    local err = assert.throws(function()
+        mm.new.InspMetaWrongType({
+            __tostring = 'not-a-function',
+        })
+    end)
+    assert.match(err, 'must be function')
+end
+
+function testcase.inspect_metamethod_string_value()
+    -- __mode and __name are allowed to be strings, not functions
+    local new_m = mm.new.InspMetaStrVal({
+        __mode = 'k',
+    })
+    assert.is_function(new_m)
+end
+
+function testcase.inspect_error_metamethod_circular_ref()
+    -- a string-type metamethod containing a circular reference must error
+    local t = {}
+    t.loop = t
+    local err = assert.throws(function()
+        mm.new.InspMetaCircular({
+            __name = t, -- __name allows non-function, deepcopy detects the cycle
+        })
+    end)
+    assert.match(err, 'circularly referenced')
+end
+
+function testcase.inspect_error_init_not_function()
+    local err = assert.throws(function()
+        mm.new.InspInitNotFn({
+            init = 'not-a-function',
+        })
+    end)
+    assert.match(err, 'field "init" must be function')
+end
+
+function testcase.inspect_error_var_circular_ref()
+    -- a non-function field (var) that contains a circular table must error
+    local t = {}
+    t.self = t
+    local err = assert.throws(function()
+        mm.new.InspVarCircular({
+            data = t,
+        })
+    end)
+    assert.match(err, 'circularly referenced')
+end
+
+-- =============================================================================
+-- embedModules() errors
+-- =============================================================================
+
+function testcase.embed_error_module_not_found()
+    -- pkg is a valid lowercase package name but require fails (not installed)
+    local err = assert.throws(function()
+        mm.new.EmbedNotFound({}, 'nonexistent.NotAMod')
+    end)
+    assert.match(err, 'cannot embed module')
+end
+
+function testcase.embed_error_not_a_package_name()
+    -- a PascalCase-only name is not a valid package name, so loadModule() skips
+    -- the require() call entirely and returns 'not found' directly
+    local err = assert.throws(function()
+        mm.new.EmbedBadPkg({}, 'UnregisteredModule')
+    end)
+    assert.match(err, 'cannot embed module')
+end
+
+function testcase.embed_error_package_loaded_but_not_metamodule()
+    -- require succeeds but the package does not call metamodule.new,
+    -- so the module name is absent from the registry → error
+    package.preload['test.mm.notmm'] = function()
+        return {} -- plain table, not a metamodule
+    end
+    local err = assert.throws(function()
+        mm.new.EmbedNotMM({}, 'test.mm.notmm')
+    end)
+    assert.match(err, 'cannot embed module')
+end
+
+function testcase.embed_error_same_module_twice()
+    -- embedding the same module in one declaration is not allowed
+    mm.new.EmbedDupBase({})
+    local err = assert.throws(function()
+        mm.new.EmbedDupChild({}, 'EmbedDupBase', 'EmbedDupBase')
+    end)
+    assert.match(err, 'cannot embed module')
+    assert.match(err, 'twice')
+end
+
+function testcase.register_error_already_registered_during_embed()
+    -- Proves register()'s REGISTRY guard: an embedded module's require() can
+    -- register the same regname as a side-effect between new()'s pre-check and
+    -- register().  An extra helper frame keeps require at lv=5 (outside
+    -- get_pkgname()'s lv=3..4 range), so both calls produce regname='RaceTarget'.
+    package.preload['test.mm.sideeffect'] = function()
+        -- register_side_effect() adds one extra frame so get_pkgname() returns nil
+        local function register_side_effect()
+            mm.new.RaceTarget({})
+        end
+        register_side_effect()
+        mm.new({}) -- pkgname='test.mm.sideeffect' (require visible at lv=4)
+    end
+
+    local err = assert.throws(function()
+        -- pkgname=nil (not in require context) → regname='RaceTarget';
+        -- embedModules loads 'test.mm.sideeffect' which registers 'RaceTarget' first
+        mm.new.RaceTarget({}, 'test.mm.sideeffect')
+    end)
+
+    package.preload['test.mm.sideeffect'] = nil
+    package.loaded['test.mm.sideeffect'] = nil
+
+    assert.match(err, 'already registered')
+end
+
+function testcase.register_custom_index_function()
+    -- when __index is defined as a function, a dynamic metatable wrapper is
+    -- generated so that named methods are checked before calling __index
+    local new_m = mm.new.RegIndexFn({
+        __index = function(_, key)
+            return 'dynamic:' .. key
+        end,
+    })
+    local obj = new_m()
+    -- unknown keys fall through to the custom __index function
+    assert.equal(obj.unknown_key, 'dynamic:unknown_key')
+    -- named methods (instanceof, init) are still accessible via the wrapper
+    assert.is_function(obj.instanceof)
+end
+
+function testcase.register_error_index_invalid_type()
+    -- inspect() also checks that __index is a function (METAFIELD_TYPES enforces this)
+    local err = assert.throws(function()
+        mm.new.RegIndexInvalid({
+            __index = 42,
+        })
+    end)
+    assert.match(err, 'must be function')
+end
+
+-- =============================================================================
+-- Instance construction and fields
+-- =============================================================================
+
+function testcase.instance_has_required_fields()
+    -- every instance has _NAME, _PACKAGE, _STRING set automatically
+    local new_m = mm.new.InstFields({})
+    local obj = new_m()
+
+    assert.equal(obj._NAME, 'InstFields')
+    assert.is_nil(obj._PACKAGE) -- no package when called outside require
+    assert.match(obj._STRING, '^InstFields: 0x', false)
+end
+
+function testcase.instance_default_init_returns_self()
+    -- without a custom init, the constructor returns the new instance
+    local new_m = mm.new.InstDefaultInit({
+        val = 'hello',
+    })
+    local obj = new_m()
+
+    assert.equal(obj.val, 'hello')
+    assert.equal(obj._NAME, 'InstDefaultInit')
+end
+
+function testcase.instance_custom_init_receives_args()
+    -- init receives all constructor arguments and can mutate self
+    local new_m = mm.new.InstCustomInit({
+        init = function(self, x, y)
+            self.sum = x + y
+            return self
+        end,
+    })
+    local obj = new_m(10, 32)
+
+    assert.equal(obj.sum, 42)
+end
+
+function testcase.instance_init_return_value_propagated()
+    -- if init returns nil, the constructor also returns nil
+    local new_m = mm.new.InstInitNil({
+        init = function()
+            return nil
+        end,
+    })
+
+    assert.is_nil(new_m())
+end
+
+function testcase.instance_default_tostring()
+    -- the default __tostring returns '<ModuleName>: <address>'
+    local new_m = mm.new.InstDefToStr({})
+    local obj = new_m()
+
+    assert.match(tostring(obj), '^InstDefToStr: 0x', false)
+end
+
+function testcase.instance_custom_tostring()
+    local new_m = mm.new.InstCustToStr({
+        __tostring = function(self)
+            return 'custom:' .. self._NAME
+        end,
+    })
+
+    assert.equal(tostring(new_m()), 'custom:InstCustToStr')
+end
+
+-- =============================================================================
+-- Embedding: method and var inheritance
+-- =============================================================================
+
+function testcase.embed_transitive_chain()
+    -- three-level chain: Top embeds Middle, Middle embeds GrandBase.
+    -- during register() the while-loop walks transitive embeds one level at a
+    -- time; GrandBase's methods must appear in Top's index table.
+    local GrandBase = {}
+    function GrandBase.grand_method(_)
+        return 'grand'
+    end
+    mm.new.TransGrandBase(GrandBase)
+
+    local Middle = {}
+    function Middle.middle_method(_)
+        return 'middle'
+    end
+    mm.new.TransMiddle(Middle, 'TransGrandBase')
+
+    local Top = {}
+    function Top.top_method(_)
+        return 'top'
+    end
+    local new_top = mm.new.TransTop(Top, 'TransMiddle')
+    local obj = new_top()
+
+    -- all three levels of methods are reachable
+    assert.equal(obj:grand_method(), 'grand')
+    assert.equal(obj:middle_method(), 'middle')
+    assert.equal(obj:top_method(), 'top')
+
+    -- transitive embedded module methods accessible by name
+    assert.equal(obj['TransGrandBase'].grand_method, GrandBase.grand_method)
+end
+
+function testcase.pkgname_from_file_path()
+    -- Tests the pathname2modname branch of get_pkgname(): when the module source
+    -- path does not contain 'metamodule', the package name is derived from the
+    -- file path rather than from require's argument.
+    local tmpdir = (os.getenv('TMPDIR') or '/tmp'):gsub('/+$', '')
+    local modfile = tmpdir .. '/mmtest_pathmod.lua'
+
+    -- write a module file outside any path containing 'metamodule'
+    local f = assert(io.open(modfile, 'w'))
+    f:write([[
+local mm = require('metamodule')
+local M = {}
+return { new = mm.new(M) }
+]])
+    f:close()
+
+    -- temporarily extend package.path so require can find the file;
+    -- require must be called directly (not via pcall/xpcall) so that the
+    -- require C frame retains its name in debug info on Lua 5.1, which
+    -- get_pkgname() depends on to identify the require frame.
+    local orig_path = package.path
+    package.path = tmpdir .. '/?.lua;' .. orig_path
+    local mod = require('mmtest_pathmod')
+    package.path = orig_path
+    os.remove(modfile)
+    package.loaded['mmtest_pathmod'] = nil
+
+    -- _NAME is derived from the file path via pathname2modname;
+    -- the exact value depends on TMPDIR but must contain the module stem
+    local obj = mod.new()
+    assert.match(obj._NAME, 'mmtest_pathmod')
+end
+
+function testcase.embed_inherits_vars_and_methods()
+    local Base = {
+        base_val = 'from-base',
+    }
+    function Base:base_method()
+        return self._NAME .. ':base'
+    end
+    mm.new.EmbedBase(Base)
+
+    local Child = {
+        child_val = 'from-child',
+    }
+    function Child:child_method()
+        return self._NAME .. ':child'
+    end
+    local new_child = mm.new.EmbedChild(Child, 'EmbedBase')
+    local obj = new_child()
+
+    -- vars from both modules are present
+    assert.equal(obj.base_val, 'from-base')
+    assert.equal(obj.child_val, 'from-child')
+
+    -- both sets of methods are callable
+    assert.equal(obj:base_method(), 'EmbedChild:base')
+    assert.equal(obj:child_method(), 'EmbedChild:child')
+
+    -- embedded module's methods are also accessible via obj['EmbedBase']
+    assert.equal(obj['EmbedBase'].base_method, Base.base_method)
+end
+
+function testcase.embed_child_field_takes_priority_over_base()
+    -- when child and base define the same field, the child's version wins
+    local BaseOvr = {
+        shared_val = 'base-val',
+    }
+    function BaseOvr.shared_method(_)
+        return 'base-method'
+    end
+    mm.new.EmbedOvrBase(BaseOvr)
+
+    local ChildOvr = {
+        shared_val = 'child-val',
+    }
+    function ChildOvr.shared_method(_)
+        return 'child-method'
+    end
+    local new_child = mm.new.EmbedOvrChild(ChildOvr, 'EmbedOvrBase')
+    local obj = new_child()
+
+    assert.equal(obj.shared_val, 'child-val')
+    assert.equal(obj:shared_method(), 'child-method')
+
+    -- the base method is still reachable via the embedded-module access table,
+    -- using dot notation with an explicit self to pass the right receiver.
+    -- (colon notation would pass obj['EmbedOvrBase'] as self, not obj itself)
+    assert.equal(obj['EmbedOvrBase'].shared_method(obj), 'base-method')
+end
+
+-- =============================================================================
+-- metamodule.instanceof()
+-- =============================================================================
+
+function testcase.instanceof_method_returns_registered_name()
+    local new_m = mm.new.InstanceofMethod({})
+    local obj = new_m()
+
+    assert.equal(obj:instanceof(), 'InstanceofMethod')
+end
+
+function testcase.instanceof_true_for_own_type()
+    local new_m = mm.new.InstanceofOwn({})
+
+    assert.is_true(mm.instanceof(new_m(), 'InstanceofOwn'))
+end
+
+function testcase.instanceof_true_for_embedded_type()
+    mm.new.InstanceofEmbBase({})
+    local new_child = mm.new.InstanceofEmbChild({}, 'InstanceofEmbBase')
+    local obj = new_child()
+
+    assert.is_true(mm.instanceof(obj, 'InstanceofEmbChild'))
+    assert.is_true(mm.instanceof(obj, 'InstanceofEmbBase'))
+end
+
+function testcase.instanceof_false_for_unrelated_type()
+    local new_m = mm.new.InstanceofFalse({})
+
+    assert.is_false(mm.instanceof(new_m(), 'SomeOtherType'))
+end
+
+function testcase.instanceof_false_for_non_metamodule_objects()
+    -- plain table without instanceof
+    assert.is_false(mm.instanceof({}, 'anything'))
+    -- non-table
+    assert.is_false(mm.instanceof('str', 'anything'))
+    -- table with instanceof function not registered in REGISTRY
+    assert.is_false(mm.instanceof({
         instanceof = function()
         end,
-    }, 'hello'))
+    }, 'anything'))
+end
 
-    -- test that throws an error if name is not string
-    local err = assert.throws(metamodule.instanceof, {})
+function testcase.instanceof_error_name_not_string()
+    local err = assert.throws(mm.instanceof, {})
     assert.match(err, 'name must be string')
 end
 
-function testcase.dump()
-    assert(pcall(function()
-        require('metamodule.test.world')
-        require('metamodule.test.hello')
-    end))
-    local metamodule = require('metamodule')
+-- =============================================================================
+-- metamodule.dump()
+-- =============================================================================
 
-    -- test that return string
-    assert.is_string(metamodule.dump())
+function testcase.dump_returns_string()
+    assert.is_string(mm.dump())
 end
+

--- a/test/normalize_test.lua
+++ b/test/normalize_test.lua
@@ -1,0 +1,52 @@
+require('luacov')
+local testcase = require('testcase')
+local assert = require('assert')
+local normalize = require('metamodule.normalize')
+
+function testcase.bare_relative_path()
+    assert.equal(normalize('a/b/c'), 'a/b/c')
+end
+
+function testcase.absolute_path_preserved()
+    assert.equal(normalize('/a/b/c'), '/a/b/c')
+end
+
+function testcase.dot_prefix_path_preserved()
+    assert.equal(normalize('./a/b'), './a/b')
+end
+
+function testcase.double_slashes_collapsed()
+    assert.equal(normalize('a//b///c'), 'a/b/c')
+    assert.equal(normalize('//a/b'), '/a/b')
+    assert.equal(normalize('.//a'), './a')
+end
+
+function testcase.dot_segments_are_removed()
+    assert.equal(normalize('a/./b'), 'a/b')
+    assert.equal(normalize('./a/./b'), './a/b')
+    assert.equal(normalize('/a/./b'), '/a/b')
+end
+
+function testcase.dotdot_removes_preceding_segment()
+    assert.equal(normalize('a/b/../c'), 'a/c')
+    assert.equal(normalize('/a/b/../c'), '/a/c')
+end
+
+function testcase.dotdot_at_root_level_is_silently_dropped()
+    -- when there is no preceding segment, '..' is consumed without error
+    assert.equal(normalize('../a'), './a')
+    assert.equal(normalize('a/b/../../c'), 'c')
+end
+
+function testcase.absolute_path_root_only()
+    assert.equal(normalize('/'), '/')
+end
+
+function testcase.empty_string()
+    assert.equal(normalize(''), '')
+end
+
+function testcase.complex_path()
+    assert.equal(normalize('/a/b/../c/./d'), '/a/c/d')
+    assert.equal(normalize('./a/b/../../c'), './c')
+end

--- a/test/seal_test.lua
+++ b/test/seal_test.lua
@@ -1,22 +1,26 @@
 require('luacov')
 local testcase = require('testcase')
+local assert = require('assert')
 local seal = require('metamodule.seal')
 
-function testcase.seal()
-    -- test that sets the metatable that contains __newindex field to table
+function testcase.seal_sets_newindex_guard()
     local tbl = {}
     seal(tbl)
     assert.is_function((getmetatable(tbl) or {}).__newindex)
+end
 
-    -- test that throws an error when attempt to add new field to sealed table
+function testcase.seal_raises_on_write()
+    local tbl = {}
+    seal(tbl)
     local err = assert.throws(function()
         tbl.foo = 'bar'
     end)
     assert.match(err,
                  'cannot change module definition after module declaration',
                  false)
+end
 
-    -- test that throws an error if argument is not table
+function testcase.seal_raises_on_non_table()
     for _, v in ipairs({
         'str',
         1,
@@ -28,7 +32,7 @@ function testcase.seal()
         coroutine.create(function()
         end),
     }) do
-        err = assert.throws(function()
+        local err = assert.throws(function()
             seal(v)
         end)
         assert.match(err, 'tbl must be table', false)


### PR DESCRIPTION
This pull request adds comprehensive unit tests for several modules, improving test coverage and clarity. The main changes include new test files for `deepcopy` and `normalize`, expanded and reorganized tests for `eval`, `is`, and `seal`, and enhanced assertions and error handling.

### New test coverage

* Added a new test file `test/deepcopy_test.lua` covering deep copy functionality, including handling of nested tables, reference isolation, and circular reference errors.
* Added a new test file `test/normalize_test.lua` with extensive tests for path normalization, covering relative/absolute paths, dot segments, double slashes, and edge cases.

### Test improvements and refactoring

* Refactored and expanded tests in `test/eval_test.lua` to include environment handling, syntax error detection, and default global evaluation.
* Renamed and reorganized test functions in `test/is_test.lua` for clarity, changing function names to `package_name`, `module_name`, and `metamethod_name`. [[1]](diffhunk://#diff-fd67a2cab83910a09622eb7d13ab04c532eafea7dadc49e0cbf9a514becc6441R3-R6) [[2]](diffhunk://#diff-fd67a2cab83910a09622eb7d13ab04c532eafea7dadc49e0cbf9a514becc6441L33-R34) [[3]](diffhunk://#diff-fd67a2cab83910a09622eb7d13ab04c532eafea7dadc49e0cbf9a514becc6441L58-R59)
* Refactored and expanded tests in `test/seal_test.lua` to separate assertions for metatable guard, error on write, and error on non-table arguments, improving readability and robustness. [[1]](diffhunk://#diff-25dbaaa8c0f2eedea96379bfdf2eb8c30a611c40fec0c5b6d10dc3fb3dc413c8R3-R23) [[2]](diffhunk://#diff-25dbaaa8c0f2eedea96379bfdf2eb8c30a611c40fec0c5b6d10dc3fb3dc413c8L31-R35)